### PR TITLE
Update Makefile phony's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 .EXPORT_ALL_VARIABLES:
-.PHONY: terraform
+.PHONY: terraform bosh cf
 
 # Environment variables that you have to set yourself:
 #


### PR DESCRIPTION
[cf-4.2.0]
Add `bosh` and `cf` to `.PHONY` in `Makefile` to avoid erroneous "Make X: target is up to date" issues when running.