### PR TITLE
Disable (not remove) daily triggers

### DIFF
--- a/ci/deploy_pipeline.yml
+++ b/ci/deploy_pipeline.yml
@@ -17,13 +17,13 @@ resource_types:
     tag: latest
 
 resources:
-- name: trigger-weekday-morning
-  type: time
-  source:
-    start: 5:00 AM
-    stop: 5:05 AM
-    location: Europe/London
-    days: [Monday, Tuesday, Wednesday, Thursday, Friday]
+# - name: trigger-weekday-morning
+#   type: time
+#   source:
+#     start: 5:00 AM
+#     stop: 5:05 AM
+#     location: Europe/London
+#     days: [Monday, Tuesday, Wednesday, Thursday, Friday]
 
 - name: paas-bootstrap-git
   type: git
@@ -56,7 +56,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloudfoundry/cf-acceptance-tests.git
-    
+
 - name: prometheus-deployment-git
   type: git
   source:
@@ -352,8 +352,8 @@ jobs:
 - name: verify-concourse
   serial: true
   plan:
-  - get: trigger-weekday-morning
-    trigger: true
+  # - get: trigger-weekday-morning
+  #   trigger: true
   - get: paas-bootstrap-git
     trigger: true
   - get: concourse-tfstate-s3
@@ -394,9 +394,9 @@ jobs:
   - aggregate:
     - get: concourse-tfstate-s3
     - get: vpc-tfstate-s3
-    - get: trigger-weekday-morning
-      trigger: true
-      passed: [verify-concourse]
+    # - get: trigger-weekday-morning
+    #   trigger: true
+    #   passed: [verify-concourse]
     - get: paas-bootstrap-git
       passed: [verify-concourse]
       trigger: true
@@ -419,9 +419,9 @@ jobs:
     - get: jumpbox-terraform
     - get: vpc-tfstate-s3
     - get: jumpbox-tfstate-s3
-    - get: trigger-weekday-morning
-      trigger: true
-      passed: [terraform-jumpbox]
+    # - get: trigger-weekday-morning
+    #   trigger: true
+    #   passed: [terraform-jumpbox]
     - get: paas-bootstrap-git
       passed: [terraform-jumpbox]
       trigger: true
@@ -448,9 +448,9 @@ jobs:
       passed: [terraform-bosh]
       params:
         output_statefile: true
-    - get: trigger-weekday-morning
-      trigger: true
-      passed: [terraform-bosh]
+    # - get: trigger-weekday-morning
+    #   trigger: true
+    #   passed: [terraform-bosh]
     - get: paas-bootstrap-git
       trigger: true
       passed: [terraform-bosh]
@@ -476,9 +476,9 @@ jobs:
     - get: jumpbox-tfstate-s3
     - get: bosh-tfstate-s3
     - get: concourse-tfstate-s3
-    - get: trigger-weekday-morning
-      trigger: true
-      passed: [terraform-bosh-databases]
+    # - get: trigger-weekday-morning
+    #   trigger: true
+    #   passed: [terraform-bosh-databases]
     - get: paas-bootstrap-git
       trigger: true
       passed: [terraform-bosh-databases]
@@ -506,9 +506,9 @@ jobs:
       passed: [terraform-cf]
       params:
         output_statefile: true
-    - get: trigger-weekday-morning
-      trigger: true
-      passed: [terraform-cf]
+    # - get: trigger-weekday-morning
+    #   trigger: true
+    #   passed: [terraform-cf]
     - get: paas-bootstrap-git
       trigger: true
       passed: [terraform-cf]
@@ -529,9 +529,9 @@ jobs:
   serial: true
   serial_groups: [rds,prometheus,smoke-tests,cats]
   plan:
-  - get: trigger-weekday-morning
-    trigger: true
-    passed: [terraform-cf-databases]
+  # - get: trigger-weekday-morning
+  #   trigger: true
+  #   passed: [terraform-cf-databases]
   - get: paas-bootstrap-git
     trigger: true
     passed: [terraform-cf-databases]
@@ -552,9 +552,9 @@ jobs:
   serial_groups: [rds,prometheus,smoke-tests,cats]
   plan:
   - aggregate:
-    - get: trigger-weekday-morning
-      trigger: true
-      passed: [verify-terraform-cf]
+    # - get: trigger-weekday-morning
+    #   trigger: true
+    #   passed: [verify-terraform-cf]
     - get: paas-bootstrap-git
       passed: [verify-terraform-cf]
       trigger: true
@@ -583,9 +583,9 @@ jobs:
   serial_groups: [rds,prometheus,smoke-tests,cats]
   plan:
   - aggregate:
-    - get: trigger-weekday-morning
-      trigger: true
-      passed: [terraform-prometheus]
+    # - get: trigger-weekday-morning
+    #   trigger: true
+    #   passed: [terraform-prometheus]
     - get: paas-bootstrap-git
       passed: [terraform-prometheus]
       trigger: true
@@ -624,9 +624,9 @@ jobs:
   serial: true
   serial_groups: [rds,prometheus,smoke-tests,cats]
   plan:
-  - get: trigger-weekday-morning
-    trigger: true
-    passed: [create-jumpbox]
+  # - get: trigger-weekday-morning
+  #   trigger: true
+  #   passed: [create-jumpbox]
   - get: paas-bootstrap-git
     passed: [create-jumpbox]
     trigger: true
@@ -663,9 +663,9 @@ jobs:
   serial_groups: [rds,prometheus,smoke-tests,cats]
   plan:
   - aggregate:
-    - get: trigger-weekday-morning
-      trigger: true
-      passed: [verify-jumpbox]
+    # - get: trigger-weekday-morning
+    #   trigger: true
+    #   passed: [verify-jumpbox]
     - get: paas-bootstrap-git
       passed: [verify-jumpbox]
       trigger: true
@@ -707,9 +707,9 @@ jobs:
   serial: true
   serial_groups: [rds,prometheus,smoke-tests,cats]
   plan:
-  - get: trigger-weekday-morning
-    trigger: true
-    passed: [create-bosh]
+  # - get: trigger-weekday-morning
+  #   trigger: true
+  #   passed: [create-bosh]
   - get: paas-bootstrap-git
     passed: [create-bosh]
     trigger: true
@@ -724,9 +724,9 @@ jobs:
   serial_groups: [rds,prometheus,smoke-tests,cats]
   plan:
   - aggregate:
-    - get: trigger-weekday-morning
-      trigger: true
-      passed: [verify-bosh]
+    # - get: trigger-weekday-morning
+    #   trigger: true
+    #   passed: [verify-bosh]
     - get: paas-bootstrap-git
       trigger: true
       passed: [verify-bosh]
@@ -790,9 +790,9 @@ jobs:
   serial: true
   serial_groups: [rds,prometheus,smoke-tests,cats]
   plan:
-  - get: trigger-weekday-morning
-    trigger: true
-    passed: [deploy-cf]
+  # - get: trigger-weekday-morning
+  #   trigger: true
+  #   passed: [deploy-cf]
   - get: paas-bootstrap-git
     passed: [deploy-cf]
     trigger: true
@@ -816,9 +816,9 @@ jobs:
   serial_groups: [smoke-tests]
   plan:
   - aggregate:
-    - get: trigger-weekday-morning
-      trigger: true
-      passed: [verify-cf-endpoints]
+    # - get: trigger-weekday-morning
+    #   trigger: true
+    #   passed: [verify-cf-endpoints]
     - get: paas-bootstrap-git
       passed: [verify-cf-endpoints]
       trigger: true
@@ -832,9 +832,9 @@ jobs:
   serial_groups: [cats]
   plan:
   - aggregate:
-    - get: trigger-weekday-morning
-      trigger: true
-      passed: [verify-cf-endpoints]
+    # - get: trigger-weekday-morning
+    #   trigger: true
+    #   passed: [verify-cf-endpoints]
     - get: paas-bootstrap-git
       trigger: true
       passed: [verify-cf-endpoints]
@@ -870,9 +870,9 @@ jobs:
   serial_groups: [prometheus]
   plan:
   - aggregate:
-    - get: trigger-weekday-morning
-      trigger: true
-      passed: [verify-cf-endpoints]
+    # - get: trigger-weekday-morning
+    #   trigger: true
+    #   passed: [verify-cf-endpoints]
     - get: paas-bootstrap-git
       trigger: true
       passed: [verify-cf-endpoints]
@@ -908,9 +908,9 @@ jobs:
   serial: true
   serial_groups: [prometheus]
   plan:
-  - get: trigger-weekday-morning
-    trigger: true
-    passed: [deploy-prometheus]
+  # - get: trigger-weekday-morning
+  #   trigger: true
+  #   passed: [deploy-prometheus]
   - get: paas-bootstrap-git
     passed: [deploy-prometheus]
     trigger: true
@@ -928,9 +928,9 @@ jobs:
   serial_groups: [prometheus]
   plan:
   - aggregate:
-    - get: trigger-weekday-morning
-      trigger: true
-      passed: [verify-prometheus]
+    # - get: trigger-weekday-morning
+    #   trigger: true
+    #   passed: [verify-prometheus]
     - get: paas-bootstrap-git
       trigger: true
       passed: [verify-prometheus]
@@ -947,18 +947,18 @@ jobs:
   serial: true
   serial_groups: [rds]
   plan:
-  - get: trigger-weekday-morning
-    trigger: true
-    passed: [verify-cf-endpoints]
+  # - get: trigger-weekday-morning
+  #   trigger: true
+  #   passed: [verify-cf-endpoints]
   - get: paas-bootstrap-git
     trigger: true
     passed: [verify-cf-endpoints]
-  - get: cf-vars-s3  
+  - get: cf-vars-s3
   - task: get management variables
     file: paas-bootstrap-git/ci/tasks/cf/get_management_vars/task.yml
     params:
       ENVIRONMENT: ((environment))
-      DOMAIN: ((domain))  
+      DOMAIN: ((domain))
   - task: create orgs spaces etc
     file: paas-bootstrap-git/ci/tasks/cf/management/task.yml
     params:
@@ -969,9 +969,9 @@ jobs:
   serial_groups: [rds]
   plan:
   - get: cf-tests-git
-  - get: trigger-weekday-morning
-    trigger: true
-    passed: [cf-management]
+  # - get: trigger-weekday-morning
+  #   trigger: true
+  #   passed: [cf-management]
   - get: paas-bootstrap-git
     trigger: true
     passed: [cf-management]
@@ -979,6 +979,6 @@ jobs:
   - task: get cf credentials
     file: paas-bootstrap-git/ci/tasks/common/get_cf_tester_credentials/task.yml
     params:
-      DOMAIN: ((domain)) 
+      DOMAIN: ((domain))
   - task: create service and test useability
     file: paas-bootstrap-git/ci/tasks/rds_broker/test_shared/task.yml

--- a/ci/destruction_pipeline.yml
+++ b/ci/destruction_pipeline.yml
@@ -11,13 +11,13 @@ resource_types:
     repository: governmentpaas/s3-resource
 
 resources:
-- name: trigger-weekday-evening
-  type: time
-  source:
-    start: 7:30 PM
-    stop: 8:00 PM
-    location: Europe/London
-    days: [Monday, Tuesday, Wednesday, Thursday, Friday]
+# - name: trigger-weekday-evening
+#   type: time
+#   source:
+#     start: 7:30 PM
+#     stop: 8:00 PM
+#     location: Europe/London
+#     days: [Monday, Tuesday, Wednesday, Thursday, Friday]
 
 - name: paas-bootstrap-git
   type: git
@@ -221,8 +221,8 @@ jobs:
   - get: manual-force
     trigger: true
     passed: [trigger-destroy]
-  - get: trigger-weekday-evening
-    trigger: true
+  # - get: trigger-weekday-evening
+  #   trigger: true
   - aggregate:
     - get: paas-bootstrap-git
     - get: bosh-vars-s3
@@ -237,9 +237,9 @@ jobs:
   serial_groups: [destruction]
   serial: true
   plan:
-  - get: trigger-weekday-evening
-    trigger: true
-    passed: [destroy-prometheus]
+  # - get: trigger-weekday-evening
+  #   trigger: true
+  #   passed: [destroy-prometheus]
   - get: manual-force
     trigger: true
     passed: [destroy-prometheus]
@@ -256,9 +256,9 @@ jobs:
   serial_groups: [destruction]
   serial: true
   plan:
-  - get: trigger-weekday-evening
-    trigger: true
-    passed: [destroy-cf]
+  # - get: trigger-weekday-evening
+  #   trigger: true
+  #   passed: [destroy-cf]
   - get: manual-force
     trigger: true
     passed: [destroy-cf]
@@ -277,9 +277,9 @@ jobs:
   serial_groups: [destruction]
   serial: true
   plan:
-  - get: trigger-weekday-evening
-    trigger: true
-    passed: [destroy-bosh]
+  # - get: trigger-weekday-evening
+  #   trigger: true
+  #   passed: [destroy-bosh]
   - get: manual-force
     trigger: true
     passed: [destroy-bosh]
@@ -303,9 +303,9 @@ jobs:
   - get: manual-force
     trigger: true
     passed: [destroy-jumpbox]
-  - get: trigger-weekday-evening
-    trigger: true
-    passed: [destroy-jumpbox]
+  # - get: trigger-weekday-evening
+  #   trigger: true
+  #   passed: [destroy-jumpbox]
   - get: paas-bootstrap-git
   - task: prometheus-empty-buckets
     file: paas-bootstrap-git/ci/tasks/destroy/empty_buckets/task.yml
@@ -336,9 +336,9 @@ jobs:
   serial_groups: [destruction]
   serial: true
   plan:
-  - get: trigger-weekday-evening
-    trigger: true
-    passed: [delete-buckets]
+  # - get: trigger-weekday-evening
+  #   trigger: true
+  #   passed: [delete-buckets]
   - get: manual-force
     trigger: true
     passed: [delete-buckets]


### PR DESCRIPTION
Disables the daily triggering of build/teardown as these pipeslines are now more designed to stay up rather than be up/down to save resources.